### PR TITLE
Issue #27: Prevents HTML entities in node titles.

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -131,14 +131,24 @@ function _auto_nodetitle_patternprocessor($pattern, $node) {
   // Replace tokens.
   global $language;
   $output = token_replace($pattern, array('node' => $node), array(
+    'callback' => '_auto_nodetitle_nohtmlentities',
     'sanitize' => FALSE,
     'clear' => FALSE,
-    'langcode' => $language->langcode
+    'langcode' => $language->langcode,
   ));
 
   $output = preg_replace('/[\t\n\r\0\x0B]/', '', strip_tags($output));
 
   return $output;
+}
+
+/**
+ * Callback function to remove HTML entities.
+ */
+function _auto_nodetitle_nohtmlentities(&$replacements, $data, $options) {
+  foreach ($replacements as $key => $value) {
+    $replacements[$key] = decode_entities($value);
+  }
 }
 
 /**
@@ -160,7 +170,7 @@ function auto_nodetitle_form_node_type_form_alter(&$form, &$form_state) {
     ),
   );
   $form['auto_nodetitle']['ant'] = array(
-    '#type' => 'radios', 
+    '#type' => 'radios',
     '#default_value' => config_get('auto_nodetitle.settings', 'ant_' . $form['#node_type']->type),
     '#options' => array(
       t('Disabled'),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/auto_nodetitle/issues/27