### PR TITLE
Issue #34: Clear token when field value is empty.

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -186,7 +186,7 @@ function _auto_nodetitle_patternprocessor($pattern, $node) {
   $output = token_replace($pattern, array('node' => $node), array(
     'callback' => '_auto_nodetitle_nohtmlentities',
     'sanitize' => FALSE,
-    'clear' => FALSE,
+    'clear' => TRUE,
     'langcode' => $language->langcode,
   ));
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/auto_nodetitle/issues/34