### PR TITLE
Issue #38: Use a link to the token browser instead of inline for performance.

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -241,7 +241,7 @@ function auto_nodetitle_form_node_type_form_alter(&$form, &$form_state) {
 
   // Display the list of available placeholders if token module is installed.
   $form['auto_nodetitle']['token_help'] = array(
-    '#theme' => 'token_tree',
+    '#theme' => 'token_tree_link',
     '#token_types' => array('node'),
   );
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/auto_nodetitle/issues/38
