### PR TITLE
Issue #33: Default to 0 (Disabled) on node type form.

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -224,7 +224,7 @@ function auto_nodetitle_form_node_type_form_alter(&$form, &$form_state) {
   );
   $form['auto_nodetitle']['ant'] = array(
     '#type' => 'radios',
-    '#default_value' => config_get('auto_nodetitle.settings', 'ant_' . $form['#node_type']->type),
+    '#default_value' => (int) config_get('auto_nodetitle.settings', 'ant_' . $form['#node_type']->type),
     '#options' => array(
       t('Disabled'),
       t('Automatically generate the title and hide the title field'),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/auto_nodetitle/issues/33