### PR TITLE
Update `auto_nodetitle` module to use full language object instead of…

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -194,7 +194,7 @@ function _auto_nodetitle_patternprocessor($pattern, $node) {
     'callback' => '_auto_nodetitle_nohtmlentities',
     'sanitize' => FALSE,
     'clear' => TRUE,
-    'langcode' => $language->langcode,
+    'language' => $language,
   ));
 
   // Strip tags.


### PR DESCRIPTION
the function call didn't use the required $options key and value for localisation